### PR TITLE
Removes duplicate package.json entry from Code Structure list in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -256,7 +256,6 @@ I suggest invoking the notify function in the following cases:
 - `mongroup.conf`, for keeping the app running.
 - `package.json`, dependency list.
 - `provision.sh`, for creating new instances.
-- `package.json`, dependency list.
 - `server.js`, with all server code.
 - `test.js`, the test suite.
 


### PR DESCRIPTION
Code Structure section of README contained duplicate entry for `package.json`